### PR TITLE
Fix package name in UnsupportedOperation’s message

### DIFF
--- a/bpost.php
+++ b/bpost.php
@@ -52,7 +52,7 @@ final class bpost extends AbstractHttpProvider implements Provider
         $address = $query->getText();
         // This API does not support IP
         if (filter_var($address, FILTER_VALIDATE_IP)) {
-            throw new UnsupportedOperation('The UrbIS provider does not support IP addresses, only street addresses.');
+            throw new UnsupportedOperation('The bpost provider does not support IP addresses, only street addresses.');
         }
 
         // Save a request if no valid address entered


### PR DESCRIPTION
Hi :)

I’ve started playing with your seemingly excellent package and discovered a tiny copy/paste oversight in an exception message.

I’ve once looked at the “documentation” for bpost’s service and it was, well, one of the most frightening thing I’ve ever seen, so I’m both impressed and delighted that someone had the courage and strength to make a Geocoder provider out of this craziness! So thanks for your work!